### PR TITLE
Fixed password variable name in Postgres Backup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To use PostgreSQL backup docker service, set the value for the following environ
 | DB_NAME | Yes | / |
 | DB_USERNAME | Yes | / |
 | DB_PASSWORD | Yes | / |
-| DB_PORT | No | 3306 |
+| DB_PORT | No | 5432 |
 | BACKUP_PATH | No | /opt/backup/ |
 
 ex:

--- a/postgres_backup/entrypoint.sh
+++ b/postgres_backup/entrypoint.sh
@@ -11,7 +11,7 @@ chmod 600 ~/.pgpass
 
 if [ "$( PGPASSWORD=${DB_PASSWORD} psql -h ${DB_HOST:-localhost} -U ${DB_USERNAME} -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" )" = '1' ]
 then
-    PGPASSWORD="${DB_PASSWORD}" pg_dump -h ${DB_HOST:-localhost} -U ${DB_USERNAME} -F t -d ${DB_NAME} > ${BACKUP_PATH:-/opt/backup}/${DB_NAME}-$(date +'%Y-%m-%d_%H-%M').tar
+    PGPASSWORD="${DB_PASSWORD}" pg_dump -h ${DB_HOST:-localhost} -U ${DB_USERNAME} -d ${DB_NAME} > ${BACKUP_PATH:-/opt/backup}/${DB_NAME}-$(date +'%Y-%m-%d_%H-%M').sql
 else
     echo "Database '${DB_NAME}' does not exist!"
     exit 1

--- a/postgres_backup/entrypoint.sh
+++ b/postgres_backup/entrypoint.sh
@@ -9,9 +9,9 @@ chmod 600 ~/.pgpass
 # Wait for postgresql to initialize
 /opt/wait-for-it.sh --timeout=3600 ${DB_HOST:-localhost}:${DB_PORT:-5432}
 
-if [ "$( psql -h ${DB_HOST:-localhost} -U ${DB_USERNAME} -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" )" = '1' ]
+if [ "$( PGPASSWORD=${DB_PASSWORD} psql -h ${DB_HOST:-localhost} -U ${DB_USERNAME} -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" )" = '1' ]
 then
-    PG_PASSWORD="${DB_PASSWORD}" pg_dump -h ${DB_HOST:-localhost} -U ${DB_USERNAME} -F t -d ${DB_NAME} > ${BACKUP_PATH:-/opt/backup}/${DB_NAME}-$(date +'%Y-%m-%d_%H-%M').tar
+    PGPASSWORD="${DB_PASSWORD}" pg_dump -h ${DB_HOST:-localhost} -U ${DB_USERNAME} -F t -d ${DB_NAME} > ${BACKUP_PATH:-/opt/backup}/${DB_NAME}-$(date +'%Y-%m-%d_%H-%M').tar
 else
     echo "Database '${DB_NAME}' does not exist!"
     exit 1


### PR DESCRIPTION
- Fixed password variable name for postgres backup service
- Updated default port in README
- Changed the output file format to .sql to keep it consistent with MySQL Backup service